### PR TITLE
deps: hotfix for mlflow dependency issue

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - lightning
 - torchmetrics
 - mlflow
-- starlette < 1.0.0  # hotfix for mlflow's starlette 1.0.0 issue
+- starlette<1.0.0  # hotfix for mlflow's starlette 1.0.0 issue
 - jsonschema
 - pyyaml
 - pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,8 @@ install_requires =
   pl-crossvalidate
   protobuf
   mlflow
-  starlette < 1.0.0  # hotfix for mlflow's starlette 1.0.0 issue
+  # hotfix for mlflow's starlette 1.0.0 issue
+  starlette<1.0.0
   jsonschema
   PyYAML
 


### PR DESCRIPTION
Close #244

This pull request applies a hotfix to address a compatibility issue between `mlflow` and `starlette` version 1.0.0 by restricting the `starlette` dependency to versions below 1.0.0. The change is applied in both the Conda environment and Python package requirements.

Dependency management:

* Restricted the `starlette` dependency to versions less than 1.0.0 in `environment.yml` to avoid issues with `mlflow` and `starlette` 1.0.0.
* Added the same version restriction for `starlette` in `setup.cfg` under `install_requires` for consistency across installation methods.