### PR TITLE
feat: add pyproject.toml for uv support (#213)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Close #213 

This pull request adds a basic build system configuration to the project, specifying the use of setuptools and wheel for building.

Build system setup:

* Added a `[build-system]` section to `pyproject.toml`, specifying `setuptools` and `wheel` as requirements and setting the build backend to `setuptools.build_meta`.